### PR TITLE
script: function jack_env

### DIFF
--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -13,6 +13,7 @@ elif [[ $(uname -s) = "Linux" ]];then
 fi
 
 ## handle command line arguments
+read -p "Do you want to sync? " choice 
 
 function help() {
     cat <<EOF
@@ -291,8 +292,10 @@ function build_variant() {
 }
 
 function jack_env() {
-    RAM=$(free | awk '/^Mem:/{ printf("%0.f", $2/(1024^2) - 1)}') #here's where the calc happens
-    export JACK_SERVER_VM_ARGUMENTS="-Dfile.encoding=UTF-8 -XX:+TieredCompilation -Xmx "$RAM"G"
+    RAM=$(free | awk '/^Mem:/{ printf("%0.f", $2/(1024^2))}') #calculating how much RAM (wow, such ram)
+    if [[ "$RAM" -lt 16 ]];then #if we're poor guys with less than 16gb
+	export JACK_SERVER_VM_ARGUMENTS="-Dfile.encoding=UTF-8 -XX:+TieredCompilation -Xmx"$((RAM -1))"G"
+    fi
 }
 
 parse_options "$@"
@@ -304,11 +307,13 @@ if [[ -z "$mainrepo" || ${#variant_codes[*]} -eq 0 ]]; then
     exit 1
 fi
 
+if [[ $choice == *"y"* ]];then
 init_release
 init_main_repo
 init_local_manifest
 init_patches
 sync_repo
+fi
 patch_things
 jack_env
 

--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -290,6 +290,11 @@ function build_variant() {
     cp "$OUT"/system.img release/"$rom_fp"/system-"$2".img
 }
 
+function jack_env() {
+    RAM=$(free | awk '/^Mem:/{ printf("%0.f", $2/(1024^2) - 1)}')
+    export JACK_SERVER_VM_ARGUMENTS="-Dfile.encoding=UTF-8 -XX:+TieredCompilation -Xmx "$RAM"G
+}
+
 parse_options "$@"
 get_rom_type "$@"
 get_variants "$@"
@@ -305,6 +310,7 @@ init_local_manifest
 init_patches
 sync_repo
 patch_things
+jack_env
 
 . build/envsetup.sh
 

--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -292,7 +292,7 @@ function build_variant() {
 
 function jack_env() {
     RAM=$(free | awk '/^Mem:/{ printf("%0.f", $2/(1024^2) - 1)}')
-    export JACK_SERVER_VM_ARGUMENTS="-Dfile.encoding=UTF-8 -XX:+TieredCompilation -Xmx "$RAM"G
+    export JACK_SERVER_VM_ARGUMENTS="-Dfile.encoding=UTF-8 -XX:+TieredCompilation -Xmx "$RAM"G"
 }
 
 parse_options "$@"

--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -291,7 +291,7 @@ function build_variant() {
 }
 
 function jack_env() {
-    RAM=$(free | awk '/^Mem:/{ printf("%0.f", $2/(1024^2) - 1)}')
+    RAM=$(free | awk '/^Mem:/{ printf("%0.f", $2/(1024^2) - 1)}') #here's where the calc happens
     export JACK_SERVER_VM_ARGUMENTS="-Dfile.encoding=UTF-8 -XX:+TieredCompilation -Xmx "$RAM"G"
 }
 


### PR DESCRIPTION
Added a function that detects how much RAM it's on the system and exports it on JACK_SERVER_VM_ARGUMENTS.
The amount of RAM that will be set it's phyisical GB amount minus 1GB to give system a "breathing room".

This should avoid in-build jack issues. 