### PR TITLE
script: avoid cleaning phh tree

### DIFF
--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -267,7 +267,9 @@ function patch_things() {
         rm -f device/*/sepolicy/common/private/genfs_contexts
         (
             cd device/phh/treble
+    if [[ $choice == *"y"* ]];then
             git clean -fdx
+    fi
             bash generate.sh "$treble_generate"
         )
         bash "$(dirname "$0")/apply-patches.sh" patches


### PR DESCRIPTION
Added an if to avoid the cleaning over phh tree if the user decide to not sync. 
This will avoid custom mks or mods by the user to be deleted.