### PR TITLE
Various fixes and enhancements for the dakkar build script

### DIFF
--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+if [ -z "$USER" ];then
+    export USER="$(id -un)"
+fi
+export LC_ALL=C
+
 ## set defaults
 
 rom_fp="$(date +%y%m%d)"

--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -312,6 +312,15 @@ if [[ -z "$mainrepo" || ${#variant_codes[*]} -eq 0 ]]; then
     exit 1
 fi
 
+# Use a python2 virtualenv if system python is python3
+python=$(python -V | awk '{print $2}' | head -c2)
+if [[ $python == "3." ]]; then
+    if [ ! -d .venv ]; then
+        virtualenv2 .venv
+    fi
+    . .venv/bin/activate
+fi
+
 init_release
 if [[ $choice == *"y"* ]];then
 init_main_repo

--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -18,7 +18,7 @@ elif [[ $(uname -s) = "Linux" ]];then
 fi
 
 ## handle command line arguments
-read -p "Do you want to sync? " choice 
+read -p "Do you want to sync? " choice
 
 function help() {
     cat <<EOF
@@ -151,10 +151,6 @@ function get_rom_type() {
                 treble_generate="slim"
                 extra_make_options="WITHOUT_CHECK_API=true"
                 ;;
-
-
-
-
         esac
         shift
     done
@@ -235,7 +231,7 @@ function init_main_repo() {
 function clone_or_checkout() {
     local dir="$1"
     local repo="$2"
-    
+
     if [[ -d "$dir" ]];then
         (
             cd "$dir"
@@ -255,7 +251,7 @@ function init_local_manifest() {
 function init_patches() {
     if [[ -n "$treble_generate" ]]; then
         clone_or_checkout patches treble_patches
-       
+
         # We don't want to replace from AOSP since we'll be applying
         # patches by hand
         rm -f .repo/local_manifests/replace.xml

--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -54,6 +54,7 @@ Variants are dash-joined combinations of (in order):
   * "vanilla" to not include GApps
   * "gapps" to include opengapps
   * "go" to include gapps go
+  * "floss" to include floss
 * SU selection ("su" or "nosu")
 
 for example:
@@ -183,6 +184,7 @@ declare -A gapps_selection_map
 gapps_selection_map[vanilla]=v
 gapps_selection_map[gapps]=g
 gapps_selection_map[go]=o
+gapps_selection_map[floss]=f
 
 declare -A su_selection_map
 su_selection_map[su]=S

--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -312,8 +312,8 @@ if [[ -z "$mainrepo" || ${#variant_codes[*]} -eq 0 ]]; then
     exit 1
 fi
 
-if [[ $choice == *"y"* ]];then
 init_release
+if [[ $choice == *"y"* ]];then
 init_main_repo
 init_local_manifest
 init_patches


### PR DESCRIPTION
Various changes I've made to the dakkar script for my purposes.

- Add the environment variables from the build script to dakkar as well. The lack of LC_ALL=C caused issues previously.
- Add a floss option.
- Automatically create and use a python2 virtualenv if the system python is 3+. Otherwise the build fails on Arch.
- Init the release folder regardless of the sync choice, since otherwise the build fails if a day passes since the last sync.
- Various whitespace things.