### PR TITLE
apt shouldn't be used for scripting.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Pierre-Hugues Husson <phh@phh.me>
 ENV DEBIAN_FRONTEND noninteractive
 ENV USER root
 RUN dpkg --add-architecture i386
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
 	build-essential \
         imagemagick \
 	xorriso \


### PR DESCRIPTION
Ubuntu's man page says that "The apt(8) commandline is designed as an end-user tool and it may change behavior between versions. While it tries not to break backward compatibility this is not guaranteed either if a change seems beneficial for interactive use."

So there's no harm, and possible benefit. So why not change it to the officially recommended tools?