### PR TITLE
Enable multithreaded xz compression

### DIFF
--- a/build-rom.sh
+++ b/build-rom.sh
@@ -86,7 +86,7 @@ buildVariant() {
 	make WITHOUT_CHECK_API=true BUILD_NUMBER=$rom_fp installclean
 	make WITHOUT_CHECK_API=true BUILD_NUMBER=$rom_fp -j$jobs systemimage
 	make WITHOUT_CHECK_API=true BUILD_NUMBER=$rom_fp vndk-test-sepolicy
-	xz -c $OUT/system.img > release/$rom_fp/system-${2}.img.xz
+	xz -c $OUT/system.img -T$jobs > release/$rom_fp/system-${2}.img.xz
 }
 
 repo manifest -r > release/$rom_fp/manifest.xml

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ buildVariant() {
 	make BUILD_NUMBER=$rom_fp installclean
 	make BUILD_NUMBER=$rom_fp -j8 systemimage
 	make BUILD_NUMBER=$rom_fp vndk-test-sepolicy
-	xz -c $OUT/system.img > release/$rom_fp/system-${2}.img.xz
+	xz -c $OUT/system.img -T0 > release/$rom_fp/system-${2}.img.xz
 }
 
 repo manifest -r > release/$rom_fp/manifest.xml


### PR DESCRIPTION
This commits enables parallelization of the compression in `build.sh` and `build-rom.sh`.

`build-rom.sh` honors the `jobs` param, and thus will use as many cores as it used for compilation. `build.sh` on the other hand will use as many cores as available (`-T0`) given the lack of a jobs parameter.

This really, really speeds up compression, going from several minutes to about half in my build server.