### PR TITLE
Fixed Typo in AOSMP

### DIFF
--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -228,7 +228,7 @@ function get_rom_type() {
 		mainbranch="pie"
 		localManifestBranch="android-9.0"
 		treble_generate="aosmp"
-		extra_make_options="WITHOUT_TREBLE_CHECK_API=true"
+		extra_make_options="WITHOUT_CHECK_API=true"
 	esac
         shift
     done


### PR DESCRIPTION
A single typo could be fatal when building treble ROM