### PR TITLE
Removing the dust and getting back to old but gold fashion.

### DIFF
--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -33,29 +33,30 @@ Options:
 
 ROM types:
 
-  aex
-  aicp
-  aokp
-  aosmp
+  aex-pie
+  aicp-oreo
+  aokp-oreo
+  aosmp-pie
   aosp80
   aosp81
   aosp90
+  aosp10
   aquarios
-  carbon
-  crdroid
+  carbon-oreo
+  crdroid-oreo
   e-pie
   e-oreo
-  havoc
-  komodo
+  havoc-pie
+  komodo-pie
   lineage151
   lineage160
-  mokee
+  mokee-oreo
   pixel81
   pixel90
-  potato
-  rebellion
-  rr
-  slim
+  potato-pie
+  rebellion-pie
+  rr-oreo
+  slim-oreo
 
 Variants are dash-joined combinations of (in order):
 * processor type
@@ -91,6 +92,7 @@ function get_rom_type() {
                 localManifestBranch="master"
                 treble_generate=""
                 extra_make_options=""
+                jack_enabled="true"
                 ;;
             aosp81)
                 mainrepo="https://android.googlesource.com/platform/manifest.git"
@@ -98,6 +100,7 @@ function get_rom_type() {
                 localManifestBranch="android-8.1"
                 treble_generate=""
                 extra_make_options=""
+                jack_enabled="true"
                 ;;
             aosp90)
                 mainrepo="https://android.googlesource.com/platform/manifest.git"
@@ -105,13 +108,23 @@ function get_rom_type() {
                 localManifestBranch="android-9.0"
                 treble_generate=""
                 extra_make_options=""
+                jack_enabled="false"
                 ;;
-            carbon)
+            aosp10)
+                mainrepo="https://android.googlesource.com/platform/manifest.git"
+                mainbranch="android-10.0.0_r2"
+                localManifestBranch="android-10.0"
+                treble_generate=""
+                extra_make_options=""
+                jack_enabled="false"
+                ;;
+            carbon-oreo)
                 mainrepo="https://github.com/CarbonROM/android.git"
                 mainbranch="cr-6.1"
                 localManifestBranch="android-8.1"
                 treble_generate="carbon"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
             e-pie)
                 mainrepo="https://gitlab.e.foundation/e/os/android/"
@@ -119,6 +132,7 @@ function get_rom_type() {
                 localManifestBranch="android-9.0"
                 treble_generate="lineage"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
                 ;;
             e-oreo)
                 mainrepo="https://gitlab.e.foundation/e/os/android/"
@@ -126,6 +140,7 @@ function get_rom_type() {
                 localManifestBranch="android-8.1"
                 treble_generate="lineage"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
             lineage151)
                 mainrepo="https://github.com/LineageOS/android.git"
@@ -133,6 +148,7 @@ function get_rom_type() {
                 localManifestBranch="android-8.1"
                 treble_generate="lineage"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
             lineage160)
                 mainrepo="https://github.com/LineageOS/android.git"
@@ -140,13 +156,15 @@ function get_rom_type() {
                 localManifestBranch="android-9.0"
                 treble_generate="lineage"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
                 ;;
-            rr)
+            rr-oreo)
                 mainrepo="https://github.com/ResurrectionRemix/platform_manifest.git"
                 mainbranch="oreo"
                 localManifestBranch="android-8.1"
                 treble_generate="rr"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
             pixel81)
                 mainrepo="https://github.com/PixelExperience/manifest.git"
@@ -154,6 +172,7 @@ function get_rom_type() {
                 localManifestBranch="android-8.1"
                 treble_generate="pixel"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
             pixel90)
                 mainrepo="https://github.com/PixelExperience/manifest.git"
@@ -161,90 +180,103 @@ function get_rom_type() {
                 localManifestBranch="android-9.0"
                 treble_generate="pixel"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
                 ;;
-            potato)
+            potato-pie)
                 mainrepo="https://github.com/PotatoProject/manifest.git"
                 mainbranch="baked-release"
                 localManifestBranch="android-9.0"
                 treble_generate="potato"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
                 ;;
-            crdroid)
+            crdroid-oreo)
                 mainrepo="https://github.com/crdroidandroid/android.git"
                 mainbranch="8.1"
                 localManifestBranch="android-8.1"
                 treble_generate="crdroid"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
-            mokee)
-                mainrepo="https://github.com/MoKee/android.git"
+            mokee-oreo)
+                mainrepo="https://github.com/mokee/android.git"
                 mainbranch="mko-mr1"
                 localManifestBranch="android-8.1"
                 treble_generate="mokee"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
-            aicp)
+            aicp-oreo)
                 mainrepo="https://github.com/AICP/platform_manifest.git"
                 mainbranch="o8.1"
                 localManifestBranch="android-8.1"
                 treble_generate="aicp"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
-            aokp)
+            aokp-oreo)
                 mainrepo="https://github.com/AOKP/platform_manifest.git"
                 mainbranch="oreo"
                 localManifestBranch="android-8.1"
                 treble_generate="aokp"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
-            aex)
+            aex-pie)
                 mainrepo="https://github.com/AospExtended/manifest.git"
                 mainbranch="9.x"
                 localManifestBranch="android-9.0"
                 treble_generate="aex"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
                 ;;
-            slim)
+            slim-oreo)
                 mainrepo="https://github.com/SlimRoms/platform_manifest.git"
                 mainbranch="or8.1"
                 localManifestBranch="android-8.1"
-                treble_generate="slim"
+                treble_generate="slimoreo"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="true"
                 ;;
-	    havoc)
+            havoc-pie)
                 mainrepo="https://github.com/Havoc-OS/android_manifest.git"
                 mainbranch="pie"
                 localManifestBranch="android-9.0"
                 treble_generate="havoc"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
                 ;;
-	   komodo)
+            komodo-pie)
                 mainrepo="https://github.com/KomodOS-Rom/platform_manifest.git"
                 mainbranch="pie"
                 localManifestBranch="android-9.0"
                 treble_generate="komodo"
                 extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
                 ;;
-	   rebellion)
-	        mainrepo="https://github.com/RebellionOS/manifest.git"
-		mainbranch="pie"
-		localManifestBranch="android-9.0"
-		treble_generate="rebellion"
-		extra_make_options="WITHOUT_CHECK_API=true"
-		;;
-	  aquarios)
-	        mainrepo="https://github.com/aquarios/manifest.git"
-		mainbranch="a9"
-		localManifestBranch="android-9.0"
-		treble_generate="aquarios"
-		extra_make_options="WITHOUT_CHECK_API=true"
-		;;
-	   aosmp)
-	   	mainrepo="https://gitlab.com/AOSmP/android_manifest.git"
-		mainbranch="pie"
-		localManifestBranch="android-9.0"
-		treble_generate="aosmp"
-		extra_make_options="WITHOUT_CHECK_API=true"
+            rebellion-pie)
+                mainrepo="https://github.com/RebellionOS/manifest.git"
+                mainbranch="pie"
+                localManifestBranch="android-9.0"
+                treble_generate="rebellion"
+                extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
+                ;;
+            aquarios)
+                mainrepo="https://github.com/aquarios/manifest.git"
+                mainbranch="a9"
+                localManifestBranch="android-9.0"
+                treble_generate="aquarios"
+                extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
+                ;;
+            aosmp-pie)
+                mainrepo="https://gitlab.com/AOSmP/android_manifest.git"
+                mainbranch="pie"
+                localManifestBranch="android-9.0"
+                treble_generate="aosmp"
+                extra_make_options="WITHOUT_CHECK_API=true"
+                jack_enabled="false"
 	esac
         shift
     done
@@ -428,22 +460,26 @@ fi
 
 init_release
 if [[ $choice == *"y"* ]];then
-init_main_repo
-init_local_manifest
-init_patches
-sync_repo
+    init_main_repo
+    init_local_manifest
+    init_patches
+    sync_repo
 fi
+
 patch_things
-jack_env
+
+if [[ $jack_enabled == "true" ]]; then
+    jack_env
+fi
+
+read -p "Do you want to clean? (y/N) " clean
+
+if [[ $clean == *"y"* ]];then
+    clean_build
+fi
 
 . build/envsetup.sh
 
 for (( idx=0; idx < ${#variant_codes[*]}; idx++ )); do
     build_variant "${variant_codes[$idx]}" "${variant_names[$idx]}"
 done
-
-read -p "Do you want to clean? (y/N) " clean
-
-if [[ $clean == *"y"* ]];then 
-clean_build
-fi

--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -234,7 +234,7 @@ function get_rom_type() {
                 mainrepo="https://github.com/SlimRoms/platform_manifest.git"
                 mainbranch="or8.1"
                 localManifestBranch="android-8.1"
-                treble_generate="slimoreo"
+                treble_generate="slim"
                 extra_make_options="WITHOUT_CHECK_API=true"
                 jack_enabled="true"
                 ;;


### PR DESCRIPTION
Beautified;
Added aosp10 target;
Relabeled previous targets to avoid confusion;
Moved execution priority of clean interaction determinated by user input;
Introduced jack_enabled for < 9.0.0 targets to selectively choose if jack_env should be fired.

**STATUS:** Currently running builds and whatnot with this commit bundled.