### PR TITLE
remove obsolete GrapheneOS pie branch

### DIFF
--- a/build-dakkar.sh
+++ b/build-dakkar.sh
@@ -284,14 +284,6 @@ function get_rom_type() {
                 extra_make_options="WITHOUT_CHECK_API=true"
                 jack_enabled="false"
                 ;;
-	    graphene9)
-	    	mainrepo="https://github.com/GrapheneOS/platform_manifest.git"
-		mainbranch="pie"
-		localManifestBranch="android-9.0"
-		treble_generate="graphene"
-		extra_make_options="WITHOUT_CHECK_API=true"
-		jack_enabled="false"
-                ;;
 	   graphene10)
 	   	mainrepo="https://github.com/GrapheneOS/platform_manifest.git"
 		mainbranch="10"


### PR DESCRIPTION
This branch no longer exists. It had not been actively developed since
August 2019 when GrapheneOS migrated to Android 10 and was obsolete when
it was added to the list here. The final state of the pie branch is
available through the PQ3B.190801.002.2019.08.25.15 tag.

The branches in GrapheneOS repositories forked from AOSP are development
workspaces with rebased patch sets. The long-term history is available
via the tags released at least once per month, not the branches. It's
maintained this way to keep it in good shape for landing code upstream,
regularly review as independent changes and ease of porting to new each
new stable release.

We deleted the branch pie branch to force explicitly referring to that
code via PQ3B.190801.002.2019.08.25.15. This makes it clear that it is a
snapshot of the project at a certain point in time. In the future, we'll
delete the legacy branches faster to avoid confusion when they're no
longer being used. The tags are how people should refer to the
historical state of the project.