### PR TITLE
Add gcam go as camera app for gapps version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,10 @@
-# Community
-
-* IRC: irc://irc.freenode.net/#phh-treble
-* WebIRC: http://webchat.freenode.net/?channels=%23phh-treble&uio=d4
-* Matrix: [#phh-treble:matrix.org](https://matrix.to/#/#phh-treble:matrix.org)
-* Telegram https://t.me/phhtreble
-* xda-developers threads: https://forum.xda-developers.com/search.php?do=finduser&u=1915408&starteronly=1
-
-# How to build
-
-* clone this repository
-* call the build scripts from a separate directory
-
-For example:
-
-    git clone https://github.com/phhusson/treble_experimentations
-    mkdir Lineage; cd Lineage
-    bash ../treble_experimentations/build-rom.sh android-8.1 lineage
-
-## More flexible build script
-
-(this has been tested much less)
-
-  bash ../treble_experimentations/build-dakkar.sh rr \
-    arm-aonly-gapps-su \
-    arm64-ab-go-nosu
-
-The script should provide a help message if you pass something it
-doesn't understand
-
-# Using Docker
-
-clone this repository, then:
-
-    docker build -t treble docker/
+GCamGOPrebuilt
+GCamGo is a stripped-down version of the Pixel’s elgoog Camera app, It is commonly used by Android One devices powered by Android GO editions. It can work with OR without GApps and with MicroG etc.
+PRODUCT_PACKAGES += \
+    GCamGOPrebuilt
+    Latest GCamGOPrebuilt packages (Experimental)
     
-    docker container create --name treble treble
-    
-    docker run -ti \
-        -v $(pwd):/treble \
-        -v $(pwd)/../treble_output:/treble_output \
-        -w /treble_output \
-        treble \
-        /bin/bash /treble/build-dakkar.sh rr \
-        arm-aonly-gapps-su \
-        arm64-ab-go-nosu
-
-# Conventions for commit messages:
-
-* `[UGLY]` Please make this patch disappear as soon as possible
-* `[master]` tag means that the commit should be dropped in a future
-  rebase
-* `[device]` tag means this change is device-specific workaround
-* `::device name::` will try to describe which devices are concerned
-  by this change
-* `[userfriendly]` This commit is NOT used for hardware support, but
-  to make the rom more user friendly
+PRODUCT_PACKAGES += \
+    GCamGOPrebuilt-V2
+    Source
+dev-greatness


### PR DESCRIPTION
the stock camera app is just useless overall well gcam go would be way way better  (better photos more user friendly more features etc)
https://github.com/ArrowOS-Devices/android_packages_apps_GCamGOPrebuilt/tree/arrow-12.0 (an example)